### PR TITLE
Make stringifying of a message conditional

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+Unpublished
+===========
+
+  * Do not stringify message if it's already a string
 
 1.1.0 / 2016-11-28
 ==================

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,9 @@ exports.publish = function (topicArn, message) {
 
   if (typeof topicArn === 'string') {
     params = { TopicArn: topicArn }
-    params.Message = JSON.stringify(message || {})
+    params.Message = typeof message === 'string'
+      ? message
+      : JSON.stringify(message || {})
   } else {
     params = assign({}, topicArn)
   }


### PR DESCRIPTION
Do not stringify the message if it's already a string.

**Rationale**

If a user passes a string message to `publish`, it's probably her
intention to send it's raw content to the subscribers (e.g. via e-mail).
Currently such a message would be passed to `JSON.stringify` first and the
result would be a JSON representation of a string (i.e. surrounded with
quotes: `'"message here"'`). Subsequently e-mail notifications would also
present these quotes, which looks weird.

**Note**

Note that this is a **breaking change** - some users may depend on the
serialization of raw strings. Thus if this PR is to be merged, I would
advise a major version bump.

To achieve previous behaviour a user would have to stringify the message
herself before passing it to publish:

```javascript
SNS.publish(topic, JSON.stringify(message));
```